### PR TITLE
fix: current playback empty response handling

### DIFF
--- a/main/RequestController.py
+++ b/main/RequestController.py
@@ -68,13 +68,11 @@ def spagett(request):
     }
     payload = {}
     response = requests.request("GET", url, headers=headers, data=payload)
-    resJson = json.loads(response.text)
-    # if(name):
-    #     if(len(response_t.objects.filter(cat=name)) != 0): # exist record
-    #         db = response_t.objects.get(cat=name)
-    #         db.data = resJson
-    #         db.save()
-    #     else: # no existing record
-    #         db = response_t(cat = name, data = resJson, updated = timezone.now())
-    #         db.save()
-    return JsonResponse(resJson, status = 200)
+    
+    if response.text == None or response.text == '':
+        return JsonResponse({'item':None}, status = 200)
+    
+    res_json = json.loads(response.text)
+    
+    return JsonResponse(res_json, status = 200)
+

--- a/static/app.js
+++ b/static/app.js
@@ -191,7 +191,7 @@ function ArtistDistribution(tracks){
 
 function show_current_playback(){
     play = spott_get('https://api.spotify.com/v1/me/player', token, function(xhr){ //scope: user-read-playback-state
-        if(xhr){
+        if(xhr && xhr['item']){
             $('#currentMeta').show();
             current_id = xhr['item']['id'];
             temp = '';


### PR DESCRIPTION
Originally, when pressing "show current playback" when you're not playing anything, an error will occur. Fixed in this PR.
Relevant issue: #6 