### PR TITLE
fix: change to select the highest quality album image

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -216,7 +216,7 @@ function show_current_playback(){
                     }
                     current_AudioFeatureDict['duration_ms'] = xhr['duration_ms'];
                     current_AudioFeatureDict['popularity'] = xhr['popularity'];
-                    $('#currentImg').html('<img src="'+xhr['album']['images'][0]['url']+'" class="meta_img">')
+                    $('#currentImg').html('<img src="'+xhr['album']['images'][2]['url']+'" class="meta_img">')
                 });
                 spott_get_sync('https://api.spotify.com/v1/audio-features/'+current_id, token, function(xhr){ //no scope
                     // console.log(xhr);


### PR DESCRIPTION
Before, the lowest quality out of the 3 versions of album images provided was chosen. It looked pretty fine before, but Spotify seemed to have changed it into super low quality, so now I change to select the highest quality version instead.