### PR TITLE
fix: show year in date axis labels

### DIFF
--- a/src/components/LineChart.tsx
+++ b/src/components/LineChart.tsx
@@ -31,7 +31,7 @@ const DateLineChart: React.FC<DateLineChartProps> = ({
       const d = new Date(item.date + '-01');
       const month = d.toLocaleString('en-US', { month: 'short' });
       const year = String(d.getFullYear()).slice(-2);
-      return `${month} '${year}`;
+      return `${month}, '${year}`;
     })()
   }));
 

--- a/src/components/LineChart.tsx
+++ b/src/components/LineChart.tsx
@@ -27,10 +27,12 @@ const DateLineChart: React.FC<DateLineChartProps> = ({
 }) => {
   const chartData = data.map(item => ({
     ...item,
-    formattedDate: new Date(item.date + '-01').toLocaleDateString('en-US', { 
-      year: '2-digit', 
-      month: 'short' 
-    })
+    formattedDate: (() => {
+      const d = new Date(item.date + '-01');
+      const month = d.toLocaleString('en-US', { month: 'short' });
+      const year = String(d.getFullYear()).slice(-2);
+      return `${month} '${year}`;
+    })()
   }));
 
   const renderCustomTooltip = ({ active, payload, label }: any) => {


### PR DESCRIPTION
## Summary
- Format date axis labels as `Mon, 'YY` (e.g. `Jan, '24`) in the **Tracks Added Over Time** and **Release Date Analysis** charts
- Uses manual string construction instead of `toLocaleDateString` to guarantee consistent output across browsers/locales

## Test plan
- [ ] Open a playlist and verify both date charts show axis labels with month and 2-digit year (e.g. `Jan, '24`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)